### PR TITLE
more sophisticated splitting for zsh

### DIFF
--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -1,5 +1,5 @@
 function preexec() {
-    command="${1%% *}"
+    command="${(Q)${(z)1}[1]}"
 }
 
 function precmd() {

--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -1,5 +1,7 @@
 function preexec() {
-    command="${(Q)${(z)1}[1]}"
+    local -a commandarray
+    commandarray=("${(z)1}")
+    command="${(Q)commandarray[1]}"
 }
 
 function precmd() {


### PR DESCRIPTION
Use the correct command if it contains quoted spaces, so command-not-found does not kick in in case of non-zero exit status.