### PR TITLE
zsh: improve handler hooking

### DIFF
--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -1,14 +1,11 @@
-function cnf_handler() {
+# define this function with two names
+#  - one to be generic command_not_found_handler() and to be hooked
+#  - one to be available when command_not_found_handler() is redefined
+function command_not_found_handler cnf_handler {
     if [ -x /usr/bin/python ] && [ -x /usr/bin/command-not-found ]; then
         # take first parameter and remove quotes if there were any so
         # $ 'foo'
         # will search for foo
         /usr/bin/python /usr/bin/command-not-found "${(Q)1}" __REPO__
     fi
-}
-
-# by default set to cnf_handler(), but users can redefine their own
-# variant and call cnf_handler() where it suits them
-function command_not_found_handler() {
-    cnf_handler "$@"
 }

--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -1,6 +1,9 @@
 function cnf_handler() {
     if [ -x /usr/bin/python ] && [ -x /usr/bin/command-not-found ]; then
-            /usr/bin/python /usr/bin/command-not-found "${1%% *}" __REPO__
+        # take first parameter and remove quotes if there were any so
+        # $ 'foo'
+        # will search for foo
+        /usr/bin/python /usr/bin/command-not-found "${(Q)1}" __REPO__
     fi
 }
 

--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -1,11 +1,11 @@
-function preexec() {
-    command="${1%% *}"
+function cnf_handler() {
+    if [ -x /usr/bin/python ] && [ -x /usr/bin/command-not-found ]; then
+            /usr/bin/python /usr/bin/command-not-found "${1%% *}" __REPO__
+    fi
 }
 
-function precmd() {
-    (($? == 127)) && [ -n "$command" ] && [ -x /usr/bin/python ] && [ -x /usr/bin/command-not-found ] && {
-        whence -- "$command" >& /dev/null ||
-            /usr/bin/python /usr/bin/command-not-found "$command" __REPO__
-        unset command
-    }
+# by default set to cnf_handler(), but users can redefine their own
+# variant and call cnf_handler() where it suits them
+function command_not_found_handler() {
+    cnf_handler "$@"
 }


### PR DESCRIPTION
- define cnf_handler function
- hook through command_not_found_handler() (thanks Roman Neuhauser for
  pointer!)

Users can now define their own preexec() and precmd() functions again
without collisions. In case they want to use their own
command_not_found_handler(), they still can call cnf_handler() wherever
they like.