### PR TITLE
Fix for bug https://bugzilla.opensuse.org/show_bug.cgi?id=980393

### DIFF
--- a/scout/bin.py
+++ b/scout/bin.py
@@ -22,13 +22,13 @@ class SolvParser(object):
 
     def __init__(self):
         self.pool = solv.Pool()
-        self.parser = SafeConfigParser()
 
         for repofile in [ f for f in os.listdir(self.etcpath) if fnmatch(f, '*.repo') ]:
             try:
-                name = os.path.splitext(repofile)[0]
-                self.parser.read( '%s/%s' % (self.etcpath, repofile) )
-                if self.parser.get(name, 'enabled') == '1':
+                parser = SafeConfigParser()
+                parser.read( '%s/%s' % (self.etcpath, repofile) )
+                name = parser.sections()[0]
+                if parser.get(name, 'enabled') == '1':
                     if not os.path.isfile(self.solvfile % name):
                         os.system('zypper refresh')
                     repo = self.pool.add_repo(name)

--- a/scout/bin.py
+++ b/scout/bin.py
@@ -27,12 +27,12 @@ class SolvParser(object):
             try:
                 parser = SafeConfigParser()
                 parser.read( '%s/%s' % (self.etcpath, repofile) )
-                name = parser.sections()[0]
-                if parser.get(name, 'enabled') == '1':
-                    if not os.path.isfile(self.solvfile % name):
-                        os.system('zypper refresh')
-                    repo = self.pool.add_repo(name)
-                    repo.add_solv(self.solvfile % name)
+                for name in parser.sections():
+                    if parser.get(name, 'enabled') == '1':
+                        if not os.path.isfile(self.solvfile % name):
+                            os.system('zypper refresh')
+                        repo = self.pool.add_repo(name)
+                        repo.add_solv(self.solvfile % name)
             except:
                 pass
         if not list(self.pool.repos_iter()):


### PR DESCRIPTION
Repo name was derived by the filename.
This fix derives the repo name from the section header of the file.

This was a problem for me, after upgrading from Leap 42.2 to 42.3.