### PR TITLE
Fix lookup of solv-file path for repos with '/' in name (bsc#1037101)

### DIFF
--- a/scout/bin.py
+++ b/scout/bin.py
@@ -29,7 +29,7 @@ class SolvParser(object):
                 parser.read( '%s/%s' % (self.etcpath, repofile) )
                 for name in parser.sections():
                     if parser.get(name, 'enabled') == '1':
-                        if not os.path.isfile(self.solvfile % name):
+                        if not os.path.isfile(self.solvfile % name.replace('/', '_')):
                             os.system('zypper refresh')
                         repo = self.pool.add_repo(name)
                         repo.add_solv(self.solvfile % name)


### PR DESCRIPTION
zypp auto-replaces '/' in names with '_' so we need to do the same here to
find the correct solv-files.