### PR TITLE
Avoid running command-not-found with python2

### DIFF
--- a/handlers/bin/command_not_found_bash
+++ b/handlers/bin/command_not_found_bash
@@ -28,7 +28,7 @@ command_not_found_handle() {
 
     if test -n "$COMMAND_NOT_FOUND_AUTO" ; then
         # call command-not-found directly
-        test -x /usr/bin/python && test -x /usr/bin/command-not-found && /usr/bin/python /usr/bin/command-not-found "$1" __REPO__
+        test -x /usr/bin/python3 && test -x /usr/bin/command-not-found && /usr/bin/command-not-found "$1" __REPO__
     else
         # print only info about command-not-found
         echo -e $"If '$1' is not a typo you can use command-not-found to lookup the package that contains it, like this:

--- a/handlers/bin/command_not_found_zsh
+++ b/handlers/bin/command_not_found_zsh
@@ -2,10 +2,10 @@
 #  - one to be generic command_not_found_handler() and to be hooked
 #  - one to be available when command_not_found_handler() is redefined
 function command_not_found_handler cnf_handler {
-    if [ -x /usr/bin/python ] && [ -x /usr/bin/command-not-found ]; then
+    if [ -x /usr/bin/python3 ] && [ -x /usr/bin/command-not-found ]; then
         # take first parameter and remove quotes if there were any so
         # $ 'foo'
         # will search for foo
-        /usr/bin/python /usr/bin/command-not-found "${(Q)1}" __REPO__
+        /usr/bin/command-not-found "${(Q)1}" __REPO__
     fi
 }


### PR DESCRIPTION
In zsh/bash handlers, command-not-found is invoked with the generic
`/usr/bin/python` interpreter, that could potentially point to a
python2 interpreter. So it's better to just check the existence of a
python3 interpreter and run `command-not-found` as an executable.

Fixes: #13

Signed-off-by: Marco Vedovati <mvedovati@suse.com>