### PR TITLE
Unicode versions of gettext are not for Python 3

### DIFF
--- a/scout/__init__.py
+++ b/scout/__init__.py
@@ -92,10 +92,10 @@ class DefaultLang(object):
         return self
 
     def gettext(self, msg):
-        return self._trans.ugettext(msg)
+        return self._trans.gettext(msg)
 
     def ngettext(self, singluar, plural, n):
-        return self._trans.ungettext(singluar, plural, n)
+        return self._trans.ngettext(singluar, plural, n)
 
     def __str__(self):
         return '%s {textdomain: %s}' % (self.__class__,


### PR DESCRIPTION
Replace all u[n]gettext methods to [n]gettext ones as Python 3
strings are already Unicode.

Fix https://github.com/openSUSE/scout/issues/16