### PR TITLE
Fix bug where sbin packages would print as bytes strings

### DIFF
--- a/handlers/bin/command-not-found
+++ b/handlers/bin/command-not-found
@@ -68,9 +68,10 @@ def check_installed(term, pkg, path):
 def find_package_by_file(term):
     ts = rpm.TransactionSet()
     mi = ts.dbMatch('basenames', term)
-    for i in mi:
-        return i['name']
-    return None
+    try:
+        return next(mi)['name'].decode()
+    except StopIteration:
+        return None
 
 
 try:


### PR DESCRIPTION
In the current version of the script, we can observe the following when running the script for a command in /usr/sbin/.
```
$ ./command-not-found swapon
                        
Program 'swapon' is present in package 'b'util-linux'', which is installed on your system.

Absolute path to 'swapon' is '/usr/sbin/swapon', so running it may require superuser privileges (eg. root).
```

Notice that the package is wrapped in a `bytes` prefix. This patch fixes that, as well as providing some minor clean up to the `find_package_by_file`.

```
$ ./command-not-found swapon
                        
Program 'swapon' is present in package 'util-linux', which is installed on your system.

Absolute path to 'swapon' is '/usr/sbin/swapon', so running it may require superuser privileges (eg. root).
``` 